### PR TITLE
Fix: set max judgments to a high value

### DIFF
--- a/.github/workflows/flat.yml
+++ b/.github/workflows/flat.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Fetch data
         uses: githubocto/flat@v3
         with:
-          http_url: https://www.lawnet.sg/lawnet/web/lawnet/free-resources?p_p_id=freeresources_WAR_lawnet3baseportlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=subordinateRSS&p_p_cacheability=cacheLevelPage&p_p_col_id=column-1&p_p_col_pos=2&p_p_col_count=3&_freeresources_WAR_lawnet3baseportlet_total=76
+          http_url: https://www.lawnet.sg/lawnet/web/lawnet/free-resources?p_p_id=freeresources_WAR_lawnet3baseportlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=subordinateRSS&p_p_cacheability=cacheLevelPage&p_p_col_id=column-1&p_p_col_pos=2&p_p_col_count=3&_freeresources_WAR_lawnet3baseportlet_total=1000
           downloaded_filename: data.xml
           postprocess: ./postprocess.ts


### PR DESCRIPTION
Ensures that all judgments are always pulled; assumes there will not be more than 1000 judgments within a 3 month period, which seems like a reasonable assumption since the usual number is less than 100.